### PR TITLE
Edit swift client

### DIFF
--- a/MyLibrary/Sources/MyLibrary/AuthService.swift
+++ b/MyLibrary/Sources/MyLibrary/AuthService.swift
@@ -1,0 +1,36 @@
+import Alamofire
+
+public protocol AuthService {
+    func getAccessToken(completion: @escaping (_ response: Result<String /* AccessToken */, Error>) -> Void)
+}
+
+class AuthServiceImpl: AuthService {
+    let url = "http://localhost:3000/v1/auth"
+
+    func getAccessToken(completion: @escaping (_ response: Result<String /* AccessToken */, Error>) -> Void) {
+        AF.request(url, method: .post, parameters: ["username": "choyongs", "password": "123456789"]).validate(statusCode: 200..<300).responseDecodable(of: Token.self) { response in
+            switch response.result {
+            case let .success(token):
+                let jwt = token.AccessToken
+                let exp = token.expires
+                print("expire date : ", exp)
+                print("jwt : ",jwt)
+                print("-------------------------------")
+                completion(.success(jwt))
+
+            case let .failure(error):
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+private struct Token: Decodable {
+    let AccessToken: String
+    let expires: String
+    
+    enum CodingKeys : String, CodingKey {
+        case AccessToken = "AccessToken"
+        case expires = "Expires"
+    }
+}

--- a/MyLibrary/Sources/MyLibrary/MyLibrary.swift
+++ b/MyLibrary/Sources/MyLibrary/MyLibrary.swift
@@ -1,6 +1,8 @@
 public class MyLibrary {
     private let weatherService: WeatherService
-
+    private let AuthService: AuthService = AuthServiceImpl()
+    private let v1Weather: v1Weather = v1WeatherImpl()
+    private let v1Hello: v1Hello = v1HelloImpl()
     /// The class's initializer.
     ///
     /// Whenever we call the `MyLibrary()` constructor to instantiate a `MyLibrary` instance,
@@ -42,4 +44,44 @@ public class MyLibrary {
     private func contains(_ lhs: Int, _ rhs: Character) -> Bool {
         return String(lhs).contains(rhs)
     }
+    
+    public func getAuth(completion: @escaping (String?) -> Void){
+        AuthService.getAccessToken { response in
+            switch response {
+            case let .failure(error):
+                print(error)
+                completion(nil)
+
+            case let .success(jwt):
+                completion(jwt)
+            }
+        }
+    }
+    
+    public func getWeather(completion: @escaping (String?) -> Void){
+        v1Weather.getWeather { response in
+            switch response {
+            case let .failure(error):
+                print(error)
+                completion(nil)
+
+            case let .success(temp):
+                completion(temp)
+            }
+        }
+    }
+    
+    public func getHello(completion: @escaping (String?) -> Void){
+        v1Hello.getHello { response in
+            switch response {
+            case let .failure(error):
+                print(error)
+                completion(nil)
+
+            case let .success(message):
+                completion(message)
+            }
+        }
+    }
+    
 }

--- a/MyLibrary/Sources/MyLibrary/v1Hello.swift
+++ b/MyLibrary/Sources/MyLibrary/v1Hello.swift
@@ -1,0 +1,50 @@
+import Alamofire
+
+public protocol v1Hello {
+    func getHello(completion: @escaping (_ response: Result<String /* hello msg */, Error>) -> Void)
+}
+
+class v1HelloImpl: v1Hello {
+    let url = "http://localhost:3000/v1/hello"
+    private let authService: AuthService = AuthServiceImpl()
+    
+    func getHello(completion: @escaping (_ response: Result<String /* hello msg */, Error>) -> Void) {
+        
+        authService.getAccessToken { response in
+            switch response {
+            case let .success(token):
+                let headers: HTTPHeaders = ["Authorization": "Bearer " + token]
+                AF.request(self.url, method: .get, headers: headers).validate(statusCode: 200..<300).responseString {
+                    response in switch response.result {
+                    case let .success(helloRes):
+                        let message = helloRes
+                        print("--------------msg-----------------")
+                        print("msg : ",message)
+                        completion(.success(message))
+                    case let .failure(Error):
+                        print(Error)
+                        completion(.failure(Error))
+                    }
+                }
+                
+            case let .failure(Error):
+                print(Error)
+            }
+        }
+
+    }
+}
+
+private struct Token: Decodable {
+    let AccessToken: String
+    let expires: String
+    
+    enum CodingKeys : String, CodingKey {
+        case AccessToken = "AccessToken"
+        case expires = "Expires"
+    }
+}
+
+private struct hello: Decodable {
+    let res: String
+}

--- a/MyLibrary/Sources/MyLibrary/v1Weather.swift
+++ b/MyLibrary/Sources/MyLibrary/v1Weather.swift
@@ -1,0 +1,54 @@
+import Alamofire
+
+public protocol v1Weather {
+    func getWeather(completion: @escaping (_ response: Result<String /* weatherData */, Error>) -> Void)
+}
+
+class v1WeatherImpl: v1Weather {
+    let url = "http://localhost:3000/v1/weather"
+    private let authService: AuthService = AuthServiceImpl()
+    
+    func getWeather(completion: @escaping (_ response: Result<String /* weatherData */, Error>) -> Void) {
+        
+        authService.getAccessToken { response in
+            switch response {
+            case let .success(token):
+                let headers: HTTPHeaders = ["Authorization": "Bearer " + token]
+                AF.request(self.url, method: .get, headers: headers).validate(statusCode: 200..<300).responseString {
+                    response in switch response.result {
+                    case let .success(Weather):
+                        let data = Weather
+                        print("weather data : ",data)
+                        completion(.success(data))
+                    case let .failure(Error):
+                        print(Error)
+                        completion(.failure(Error))
+                    }
+                    
+                }
+                
+            case let .failure(Error):
+                print(Error)
+            }
+        }
+
+    }
+}
+
+private struct Token: Decodable {
+    let AccessToken: String
+    let expires: String
+    
+    enum CodingKeys : String, CodingKey {
+        case AccessToken = "AccessToken"
+        case expires = "Expires"
+    }
+}
+
+private struct Weather: Decodable {
+    let main: Main
+
+    struct Main: Decodable {
+        let temp: Double
+    }
+}

--- a/MyLibrary/Tests/MyLibraryTests/MyLibraryTests.swift
+++ b/MyLibrary/Tests/MyLibraryTests/MyLibraryTests.swift
@@ -101,4 +101,67 @@ final class MyLibraryTests: XCTestCase {
         XCTAssertNil(isLuckyNumber)
     }
 
+    func testAuth() throws {
+        // Given
+
+        let myLibrary = MyLibrary()
+        let expectation = XCTestExpectation(description: "We asked about the access token and get jwt token")
+        var jwt : String?
+
+        // When
+        myLibrary.getAuth(completion: { token in
+            print("================")
+            print(token as Any)
+            jwt = token
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 5)
+
+        // Then
+        XCTAssertNotNil(jwt)
+    }
+    
+    func testv1Weather() throws {
+        // Given
+
+        let myLibrary = MyLibrary()
+        let expectation = XCTestExpectation(description: "We asked about weather data by using jwt token")
+        var temp : String?
+
+        // When
+        myLibrary.getWeather(completion: { res in
+            print("================Corvallis temperature===============")
+            print(res as Any)
+            temp = res
+            print("===================finished test====================")
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 5)
+
+        // Then
+        XCTAssertNotNil(temp)
+    }
+    
+    func testv1Hello() throws {
+        // Given
+
+        let myLibrary = MyLibrary()
+        let expectation = XCTestExpectation(description: "We asked about weather data by using jwt token")
+        var message : String?
+
+        // When
+        myLibrary.getHello(completion: { res in
+            print("================message===============")
+            print(res as Any)
+            message = res
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 5)
+
+        // Then
+        XCTAssertNotNil(message)
+    }
 }


### PR DESCRIPTION
Update your Swift client, so that it can access the protected versions of /v1/hello and /v1/weather.  Your client should be able to authenticate on its own—do not hardcode your JWT inside your client—and then, upon successful completion, access your secure endpoints.  You will want new data models, so that you can deserialize the JSON responses from all three endpoints, as well as tests to run them.  Given your code, we should be able to run swift test and this should run two tests: testHello and testWeather.  Do not worry about unit tests.  Instead, make these integration tests. 